### PR TITLE
[PR] NavigationBar UI Components 구현

### DIFF
--- a/Projects/UI/Sources/NavigationBar/SMMainNavigationBar.swift
+++ b/Projects/UI/Sources/NavigationBar/SMMainNavigationBar.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+public struct SMMainNavigationBar: ViewModifier {
+  @Binding var selection: Int
+  let color: Color
+  let profileImage: Image
+  let addAction: () -> Void
+  let profileAction: () -> Void
+  
+  public init(
+    selection: Binding<Int>,
+    color: Color,
+    profileImage: Image,
+    addAction: @escaping () -> Void,
+    profileAction: @escaping () -> Void
+  ) {
+    self._selection = selection
+    self.color = color
+    self.profileImage = profileImage
+    self.addAction = addAction
+    self.profileAction = profileAction
+  }
+  
+  public func body(content: Content) -> some View {
+    content
+      .toolbar {
+        ToolbarItem(placement: .navigationBarLeading) {
+          Text("Home")
+            .font(.title2).bold()
+            .foregroundColor(selection == 0 ? UIAsset.green1.swiftUIColor : UIAsset.white36.swiftUIColor)
+            .onTapGesture {
+              withAnimation {
+                selection = 0
+              }
+            }
+        }
+        
+        ToolbarItem(placement: .navigationBarLeading) {
+          Text("Best")
+            .font(.title2).bold()
+            .foregroundColor(selection == 1 ? UIAsset.green1.swiftUIColor : UIAsset.white36.swiftUIColor)
+            .onTapGesture {
+              withAnimation {
+                selection = 1
+              }
+            }
+        }
+        
+        ToolbarItem(placement: .navigationBarTrailing) {
+          Circle().fill(UIAsset.green1.swiftUIColor)
+            .frame(width: 32)
+            .overlay(
+              UIAsset.plus.swiftUIImage
+                .renderingMode(.template)
+                .scaledToFit()
+                .foregroundColor(UIAsset.black.swiftUIColor)
+                .frame(width: 10)
+            )
+            .onTapGesture(perform: addAction)
+        }
+        
+        ToolbarItem(placement: .navigationBarTrailing) {
+          profileImage
+            .resizable()
+            .scaledToFit()
+            .frame(width: 32, height: 32)
+            .clipShape(Circle())
+            .onTapGesture(perform: profileAction)
+        }
+      }
+      .toolbarBackground(color, for: .navigationBar)
+      .toolbarBackground(.visible, for: .navigationBar)
+      .navigationBarTitleDisplayMode(.inline)
+      .navigationBarBackButtonHidden(true)
+  }
+}
+
+public extension View {
+  func smMainNavigationBar(
+    selection: Binding<Int>,
+    color: Color = UIAsset.black.swiftUIColor,
+    profile: Image,
+    addAction: @escaping () -> Void,
+    profileAction: @escaping () -> Void
+  ) -> some View{
+    modifier(SMMainNavigationBar(
+      selection: selection,
+      color: color,
+      profileImage: profile,
+      addAction: addAction,
+      profileAction: profileAction
+    ))
+  }
+}

--- a/Projects/UI/Sources/NavigationBar/SMNavigationBar.swift
+++ b/Projects/UI/Sources/NavigationBar/SMNavigationBar.swift
@@ -40,12 +40,12 @@ public extension View {
     title: String,
     @ViewBuilder leftItems: @escaping () -> some View,
     @ViewBuilder rightItems: @escaping () -> some View,
-    color: Color = .black
+    color: Color = UIAsset.black.swiftUIColor
   ) -> some View {
     modifier(SMNavigationBar(
       leftItems: leftItems,
       rightItems: rightItems,
-      title: { Text(title).foregroundColor(.white) },
+      title: { Text(title).foregroundColor(UIAsset.white.swiftUIColor) },
       color: color
     ))
   }

--- a/Projects/UI/Sources/NavigationBar/SMNavigationBar.swift
+++ b/Projects/UI/Sources/NavigationBar/SMNavigationBar.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+public struct SMNavigationBar<L, C, R>: ViewModifier where L: View, C: View, R: View {
+  
+  let leftItems: () -> L
+  let rightItems: () -> R
+  let title: () -> C
+  let color: Color
+  
+  public init(
+    @ViewBuilder leftItems: @escaping () -> L,
+    @ViewBuilder rightItems: @escaping () -> R,
+    @ViewBuilder title: @escaping () -> C,
+    color: Color
+  ) {
+    self.leftItems = leftItems
+    self.rightItems = rightItems
+    self.title = title
+    self.color = color
+  }
+  
+  public func body(content: Content) -> some View {
+    content
+      .toolbar {
+        ToolbarItem(placement: .principal, content: title)
+        ToolbarItem(placement: .navigationBarLeading, content: leftItems)
+        ToolbarItem(placement: .navigationBarTrailing, content: rightItems)
+      }
+      .toolbarBackground(color, for: .navigationBar)
+      .toolbarBackground(.visible, for: .navigationBar)
+      .navigationBarTitleDisplayMode(.inline)
+      .navigationBarBackButtonHidden(true)
+  }
+}
+
+public extension View {
+  
+  // title, color 형태를 고정한 매서드
+  func smNavigationBar(
+    title: String,
+    @ViewBuilder leftItems: @escaping () -> some View,
+    @ViewBuilder rightItems: @escaping () -> some View,
+    color: Color = .black
+  ) -> some View {
+    modifier(SMNavigationBar(
+      leftItems: leftItems,
+      rightItems: rightItems,
+      title: { Text(title).foregroundColor(.white) },
+      color: color
+    ))
+  }
+  
+  // 가장 일반적인 매서드
+  func smNavigationBar(
+    @ViewBuilder _ lefts: @escaping () -> some View,
+    @ViewBuilder _ rights: @escaping () -> some View,
+    @ViewBuilder _ title: @escaping () -> some View,
+    _ color: Color
+  ) -> some View {
+    modifier(
+      SMNavigationBar(leftItems: lefts, rightItems: lefts, title: lefts, color: color)
+    )
+  }
+}


### PR DESCRIPTION
## 📌 연관 이슈

- #3 

## 🧑‍💻 작업 내역
- [x] SMMainNavigationBar
- [x] SMNavigationBar

## 📷 스크린샷

<img src = "https://github.com/Sal-Mal/salmal-iOS/assets/69573768/1d8c47a3-63b5-484a-bc59-cb1f3ee4b7fd" width = 200>

<img src = "https://github.com/Sal-Mal/salmal-iOS/assets/69573768/ebb69b0f-873d-4776-9967-087bc0b7d35e" width = 200>

## 🧐 고민

- modifier 방식으로 만들었는데 괜찮나요?

- 그리고 Home, Best 저건 폰트로 해야겠죠?? (Image가 아니라..?)

- 또 modifier 방식으로 하니까 문제가 NavigationBar 자체의 높이를 좀 늘리고 싶은데 그게 안되네요
두번째화면의 + 아이콘이 밑에 여백이 너무 적어보임..

close #3
