### PR TITLE
[PR] Toast Message UI Components

### DIFF
--- a/Projects/UI/DemoApp/Sources/App/ContentView.swift
+++ b/Projects/UI/DemoApp/Sources/App/ContentView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 enum Demo: String, CaseIterable {
-  case fonts = "Fonts"
-  case colors = "Colors"
+  case fonts = "폰트"
+  case colors = "컬러"
+  case toasts = "토스트"
 
   @ViewBuilder var content: some View {
     switch self {
@@ -10,6 +11,8 @@ enum Demo: String, CaseIterable {
       FontView()
     case .colors:
       ColorView()
+    case .toasts:
+      ToastView()
     }
   }
 }

--- a/Projects/UI/DemoApp/Sources/Scene/ColorView.swift
+++ b/Projects/UI/DemoApp/Sources/Scene/ColorView.swift
@@ -23,8 +23,18 @@ struct ColorView: View {
         ColorExample(title: "White36", color: .ds(.white36))
         ColorExample(title: "White80", color: .ds(.white80))
       }
+
+      Section("Rainbows") {
+        ColorExample(title: "Red", color: .ds(.red))
+        ColorExample(title: "Orange", color: .ds(.orange))
+        ColorExample(title: "Yellow", color: .ds(.yellow))
+        ColorExample(title: "Green", color: .ds(.green))
+        ColorExample(title: "Blue", color: .ds(.blue))
+        ColorExample(title: "Purple", color: .ds(.purple))
+        ColorExample(title: "Apricot", color: .ds(.apricot))
+      }
     }
-    .navigationTitle("Colors")
+    .navigationTitle("컬러")
   }
 }
 

--- a/Projects/UI/DemoApp/Sources/Scene/FontView.swift
+++ b/Projects/UI/DemoApp/Sources/Scene/FontView.swift
@@ -51,7 +51,7 @@ struct FontView: View {
             .font(.twaySky(size: 20))
         }
       }
-      .navigationTitle("Fonts")
+      .navigationTitle("폰트")
     }
 }
 

--- a/Projects/UI/DemoApp/Sources/Scene/ToastView.swift
+++ b/Projects/UI/DemoApp/Sources/Scene/ToastView.swift
@@ -1,0 +1,66 @@
+//
+//  ToastView.swift
+//  UI
+//
+//  Created by 청새우 on 2023/09/06.
+//
+
+import SwiftUI
+import UI
+
+struct ToastView: View {
+
+  @State private var toast: SMToast?
+
+  var body: some View {
+    List {
+      Button {
+        toast = SMToast(type: .success("토스트 테스트 메시지입니다."))
+      } label: {
+        Text("[성공] 토스트")
+          .font(.ds(.title3))
+          .foregroundColor(.ds(.black))
+      }
+
+      Button {
+        toast = SMToast(type: .warning("토스트 테스트 메시지입니다."))
+      } label: {
+        Text("[경고] 토스트")
+          .font(.ds(.title3))
+          .foregroundColor(.ds(.black))
+      }
+
+      Button {
+        toast = SMToast(type: .error("토스트 테스트 메시지입니다."))
+      } label: {
+        Text("[에러] 토스트")
+          .font(.ds(.title3))
+          .foregroundColor(.ds(.black))
+      }
+
+      Button {
+        toast = SMToast(type: .success("테스트"))
+      } label: {
+        Text("짧은 글 토스트")
+          .font(.ds(.title3))
+          .foregroundColor(.ds(.black))
+      }
+
+      Button {
+        toast = SMToast(type: .success("토스트 테스트 메시지입니다. 토스트 테스트 메시지입니다."))
+      } label: {
+        Text("긴 글 토스트")
+          .font(.ds(.title3))
+          .foregroundColor(.ds(.black))
+      }
+    }
+    .navigationTitle("토스트")
+    .toast(on: $toast)
+  }
+}
+
+struct ToastView_Previews: PreviewProvider {
+  static var previews: some View {
+    ToastView()
+  }
+}

--- a/Projects/UI/Sources/Components/Toast/SMToastModifier.swift
+++ b/Projects/UI/Sources/Components/Toast/SMToastModifier.swift
@@ -1,0 +1,56 @@
+//
+//  SMToastModifier.swift
+//  UI
+//
+//  Created by 청새우 on 2023/09/06.
+//
+
+import SwiftUI
+
+struct SMToastModifier: ViewModifier {
+
+  @Binding var toast: SMToast?
+  @State private var workItem: DispatchWorkItem?
+  @State private var showToast: Bool = false
+
+  func body(content: Content) -> some View {
+    content
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .overlay(
+        ZStack {
+          if let toast {
+            VStack {
+              Spacer()
+              SMToastView(for: toast.type)
+                .offset(y: showToast ? -18 : 0)
+            }
+          }
+        }
+        .animation(.spring(), value: toast)
+        .animation(.easeOut(duration: 0.2), value: showToast)
+      )
+      .onChange(of: toast) { newToast in
+        guard let newToast else { return }
+
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+
+        if newToast.duration > .zero {
+          workItem?.cancel()
+
+          let task = DispatchWorkItem {
+            withAnimation {
+              showToast = false
+              toast = nil
+            }
+
+            workItem?.cancel()
+            workItem = nil
+          }
+
+          workItem = task
+          showToast = true
+          DispatchQueue.main.asyncAfter(deadline: .now() + newToast.duration, execute: task)
+        }
+      }
+  }
+}

--- a/Projects/UI/Sources/Components/Toast/SMToastView.swift
+++ b/Projects/UI/Sources/Components/Toast/SMToastView.swift
@@ -45,7 +45,7 @@ public struct SMToastView: View {
       case .warning:
         return .ds(.orange)
       case .success:
-        return .ds(.green)
+        return .ds(.green1)
       }
     }
 

--- a/Projects/UI/Sources/Components/Toast/SMToastView.swift
+++ b/Projects/UI/Sources/Components/Toast/SMToastView.swift
@@ -1,0 +1,124 @@
+//
+//  SMToastView.swift
+//  UI
+//
+//  Created by 청새우 on 2023/09/06.
+//
+
+import SwiftUI
+
+public struct SMToast: Equatable {
+  let type: SMToastView.ToastType
+  let duration: TimeInterval
+
+  public init(
+    type: SMToastView.ToastType,
+    duration: TimeInterval = 3.0
+  ) {
+    self.type = type
+    self.duration = duration
+  }
+}
+
+public struct SMToastView: View {
+
+  public enum ToastType: Equatable {
+    case error(String)
+    case warning(String)
+    case success(String)
+
+    var title: String {
+      switch self {
+      case .error(let title):
+        return title
+      case .warning(let title):
+        return title
+      case .success(let title):
+        return title
+      }
+    }
+
+    var color: Color {
+      switch self {
+      case .error:
+        return .ds(.red)
+      case .warning:
+        return .ds(.orange)
+      case .success:
+        return .ds(.green)
+      }
+    }
+
+    var iconImage: Image {
+      switch self {
+      case .error:
+        return .init(icon: .delete)
+      case .warning:
+        return .init(icon: .warning)
+      case .success:
+        return .init(icon: .check)
+      }
+    }
+
+    var iconSize: CGFloat {
+      switch self {
+      case .success:
+        return 12.0
+      default:
+        return 18.0
+      }
+    }
+  }
+
+  private let title: String
+  private let type: ToastType
+
+  public init(
+    for type: ToastType
+  ) {
+    self.title = type.title
+    self.type = type
+  }
+
+  public var body: some View {
+    HStack {
+      Circle()
+        .fill(type.color)
+        .frame(width: 24, height: 24)
+        .overlay {
+          type.iconImage
+            .resizable()
+            .aspectRatio(1, contentMode: .fit)
+            .frame(width: type.iconSize, height: type.iconSize)
+        }
+
+      Text(title)
+        .font(.ds(.title4))
+        .foregroundColor(.ds(.white))
+    }
+    .padding()
+    .frame(height: 48)
+    .background(Color.ds(.gray4))
+    .cornerRadius(24)
+    .shadow(radius: 4)
+  }
+}
+
+struct SMToastView_Previews: PreviewProvider {
+
+  static var previews: some View {
+    Group {
+      SMToastView(for: .success("살말 업로드 완료!"))
+        .previewDisplayName("성공 토스트")
+        .previewLayout(.sizeThatFits)
+
+      SMToastView(for: .warning("화면 캡처를 감지했어요."))
+        .previewDisplayName("경고 토스트")
+        .previewLayout(.sizeThatFits)
+
+      SMToastView(for: .error("더 이상 해당 사용자가 피드에서 보이지 않아요."))
+        .previewDisplayName("에러 토스트")
+        .previewLayout(.sizeThatFits)
+    }
+  }
+}

--- a/Projects/UI/Sources/Components/Toast/SMToastView.swift
+++ b/Projects/UI/Sources/Components/Toast/SMToastView.swift
@@ -99,7 +99,7 @@ public struct SMToastView: View {
     .padding()
     .frame(height: 48)
     .background(Color.ds(.gray4))
-    .cornerRadius(24)
+    .clipShape(Capsule())
     .shadow(radius: 4)
   }
 }

--- a/Projects/UI/Sources/Extension/View+Extension.swift
+++ b/Projects/UI/Sources/Extension/View+Extension.swift
@@ -5,4 +5,8 @@ extension View {
   func debug(_ color: Color = .red) -> some View {
     modifier(FrameDebugModifier(color: color))
   }
+
+  public func toast(on toast: Binding<SMToast?>) -> some View {
+    modifier(SMToastModifier(toast: toast))
+  }
 }


### PR DESCRIPTION
## 📌 연관 이슈
- #9 

## 🧑‍💻 작업 내역
- [x] SMToastView
- [x] SMToastModifier
- 성공, 경고, 에러의 3가지 타입으로 띄울 수 있도록 구현
- 누락된 데모 앱 Color 추가

## 📷 스크린샷
![스크린샷 2023-09-06 오후 11 52 45](https://github.com/Sal-Mal/salmal-iOS/assets/94151993/0bb5f5c2-144f-4553-a375-c71fe3a8d2b5)
![스크린샷 2023-09-06 오후 11 52 28](https://github.com/Sal-Mal/salmal-iOS/assets/94151993/a5296704-21bc-4e4d-a40f-d2a5dd756637)
![스크린샷 2023-09-06 오후 11 52 23](https://github.com/Sal-Mal/salmal-iOS/assets/94151993/938e21c1-f5f8-472c-9621-93ef255623dd)
![스크린샷 2023-09-06 오후 11 52 18](https://github.com/Sal-Mal/salmal-iOS/assets/94151993/55ad4103-51c0-48d0-9eb4-c226401d11cd)

## 🧐 고민

close #9 
